### PR TITLE
Caching user repositories

### DIFF
--- a/bin/github-repos
+++ b/bin/github-repos
@@ -15,7 +15,9 @@ def usage!
   puts 'Commands:'
   puts '  authenticate <email> <token>'
   puts '  search <query>'
+  puts '  search-all <query>'
   puts '  host <hostname>'
+  puts '  reset-cache'
   exit
 end
 
@@ -72,7 +74,27 @@ def search(query)
   return not_authenticated_output unless repos
   return no_results_output if repos.empty?
 
-  Github::RepoFormatter.new(repos).to_json
+  JSON.generate(items: repos)
+rescue Github::Authorization::NotAuthorizedError
+  not_authenticated_output
+rescue JSON::ParserError
+  error_output
+end
+
+def search_all(query)
+  repos = Github::Api.new.search_all_repos(query)
+  return not_authenticated_output unless repos
+  return no_results_output if repos.empty?
+
+  JSON.generate(items: repos)
+rescue Github::Authorization::NotAuthorizedError
+  not_authenticated_output
+rescue JSON::ParserError
+  error_output
+end
+
+def reset_cache
+  Github::Api.new.reset_cache
 rescue Github::Authorization::NotAuthorizedError
   not_authenticated_output
 rescue JSON::ParserError
@@ -86,6 +108,10 @@ when 'authenticate'
   authenticate(ARGV[1], ARGV[2])
 when 'search'
   puts search(ARGV[1])
+when 'search-all'
+  puts search_all(ARGV[1])
+when 'reset-cache'
+  reset_cache
 else
   return usage!
 end

--- a/info.plist
+++ b/info.plist
@@ -242,9 +242,9 @@
 				<key>argumenttype</key>
 				<integer>2</integer>
 				<key>keyword</key>
-				<string>gh-reset-hash</string>
+				<string>gh-reset-cache</string>
 				<key>subtext</key>
-				<string>gh-reset-hash</string>
+				<string>gh-reset-cache</string>
 				<key>text</key>
 				<string>Update github cache</string>
 				<key>withspace</key>

--- a/info.plist
+++ b/info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>bundleid</key>
 	<string>edgarjs.github-repos.workflow</string>
-	<key>category</key>
-	<string>Internet</string>
 	<key>connections</key>
 	<dict>
 		<key>2BD5A2D8-1263-445C-818F-1149B117043F</key>
@@ -64,6 +62,32 @@
 		</array>
 		<key>7FD2F7D8-60D9-49F4-BA70-C256B0426A38</key>
 		<array/>
+		<key>B6461D97-4545-4CC6-8441-EBB26BB5E8E3</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>CE432EBB-9EC4-4951-BD09-36414AF0AD62</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>B95D5B79-1099-4505-8C73-B9432D0FEF27</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>F2578320-696B-4844-AE63-6A9B88C77B26</key>
 		<array>
 			<dict>
@@ -92,20 +116,39 @@
 			<key>config</key>
 			<dict>
 				<key>argumenttype</key>
-				<integer>0</integer>
+				<integer>2</integer>
 				<key>keyword</key>
-				<string>gh-host</string>
+				<string>gh-notifications</string>
 				<key>subtext</key>
-				<string>gh-host &lt;https://hostname&gt;</string>
+				<string>https://github.com/notifications</string>
 				<key>text</key>
-				<string>Set your enterprise host</string>
+				<string>Open your Github notifications page</string>
 				<key>withspace</key>
-				<true/>
+				<false/>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.input.keyword</string>
 			<key>uid</key>
-			<string>2BD5A2D8-1263-445C-818F-1149B117043F</string>
+			<string>381B37AB-78A2-43C6-9D32-878D4A81B5B5</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>https://github.com/notifications</string>
+				<key>utf8</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>7B59839B-A868-4F5C-8A93-5AFD865D55AE</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -131,6 +174,27 @@
 			<string>7FD2F7D8-60D9-49F4-BA70-C256B0426A38</string>
 			<key>version</key>
 			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>keyword</key>
+				<string>gh-host</string>
+				<key>subtext</key>
+				<string>gh-host &lt;https://hostname&gt;</string>
+				<key>text</key>
+				<string>Set your enterprise host</string>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>2BD5A2D8-1263-445C-818F-1149B117043F</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -175,42 +239,46 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
-				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>https://github.com/notifications</string>
-				<key>utf8</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
-			<key>uid</key>
-			<string>7B59839B-A868-4F5C-8A93-5AFD865D55AE</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>argumenttype</key>
 				<integer>2</integer>
 				<key>keyword</key>
-				<string>gh-notifications</string>
+				<string>gh-reset-hash</string>
 				<key>subtext</key>
-				<string>https://github.com/notifications</string>
+				<string>gh-reset-hash</string>
 				<key>text</key>
-				<string>Open your Github notifications page</string>
+				<string>Update github cache</string>
 				<key>withspace</key>
 				<false/>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.input.keyword</string>
 			<key>uid</key>
-			<string>381B37AB-78A2-43C6-9D32-878D4A81B5B5</string>
+			<string>B95D5B79-1099-4505-8C73-B9432D0FEF27</string>
 			<key>version</key>
 			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>./bin/github-repos reset-cache</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -259,21 +327,51 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<true/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>gha</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<false/>
+				<key>queuedelaymode</key>
+				<integer>1</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string>Fetching results...</string>
+				<key>script</key>
+				<string>bin/github-repos search-all $1</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
 				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>{query}</string>
-				<key>utf8</key>
+				<key>subtext</key>
+				<string>gha &lt;repo&gt;</string>
+				<key>title</key>
+				<string>Type repository name</string>
+				<key>type</key>
+				<integer>0</integer>
+				<key>withspace</key>
 				<true/>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
+			<string>alfred.workflow.input.scriptfilter</string>
 			<key>uid</key>
-			<string>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</string>
+			<string>B6461D97-4545-4CC6-8441-EBB26BB5E8E3</string>
 			<key>version</key>
-			<integer>1</integer>
+			<integer>3</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -324,6 +422,44 @@
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>CE432EBB-9EC4-4951-BD09-36414AF0AD62</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string>1. Call `gh-token` to generate personal access token.
@@ -355,9 +491,9 @@ NOTE: This is an experimental feature that may not work as expected, if you find
 		<key>381B37AB-78A2-43C6-9D32-878D4A81B5B5</key>
 		<dict>
 			<key>xpos</key>
-			<integer>460</integer>
+			<integer>450</integer>
 			<key>ypos</key>
-			<integer>210</integer>
+			<integer>15</integer>
 		</dict>
 		<key>4EADFDC9-FA77-4A5E-AC45-FFCF4560CD23</key>
 		<dict>
@@ -365,6 +501,13 @@ NOTE: This is an experimental feature that may not work as expected, if you find
 			<integer>280</integer>
 			<key>ypos</key>
 			<integer>290</integer>
+		</dict>
+		<key>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</key>
+		<dict>
+			<key>xpos</key>
+			<integer>640</integer>
+			<key>ypos</key>
+			<integer>165</integer>
 		</dict>
 		<key>5A5FFC2F-634C-4DD4-A895-CB0E3C61BDD8</key>
 		<dict>
@@ -390,9 +533,9 @@ NOTE: This is an experimental feature that may not work as expected, if you find
 		<key>7B59839B-A868-4F5C-8A93-5AFD865D55AE</key>
 		<dict>
 			<key>xpos</key>
-			<integer>650</integer>
+			<integer>640</integer>
 			<key>ypos</key>
-			<integer>210</integer>
+			<integer>15</integer>
 		</dict>
 		<key>7FD2F7D8-60D9-49F4-BA70-C256B0426A38</key>
 		<dict>
@@ -401,10 +544,31 @@ NOTE: This is an experimental feature that may not work as expected, if you find
 			<key>ypos</key>
 			<integer>20</integer>
 		</dict>
+		<key>B6461D97-4545-4CC6-8441-EBB26BB5E8E3</key>
+		<dict>
+			<key>xpos</key>
+			<integer>465</integer>
+			<key>ypos</key>
+			<integer>440</integer>
+		</dict>
+		<key>B95D5B79-1099-4505-8C73-B9432D0FEF27</key>
+		<dict>
+			<key>xpos</key>
+			<integer>450</integer>
+			<key>ypos</key>
+			<integer>165</integer>
+		</dict>
 		<key>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</key>
 		<dict>
 			<key>xpos</key>
 			<integer>280</integer>
+			<key>ypos</key>
+			<integer>440</integer>
+		</dict>
+		<key>CE432EBB-9EC4-4951-BD09-36414AF0AD62</key>
+		<dict>
+			<key>xpos</key>
+			<integer>695</integer>
 			<key>ypos</key>
 			<integer>440</integer>
 		</dict>
@@ -419,7 +583,7 @@ NOTE: This is an experimental feature that may not work as expected, if you find
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>webaddress</key>
 	<string>https://github.com/edgarjs/alfred-github-repos</string>
 </dict>

--- a/lib/github/api.rb
+++ b/lib/github/api.rb
@@ -112,6 +112,8 @@ module Github
     end
 
     def get_next_page(header)
+      return unless header
+
       # GitHub pagination returns a "Link" header in the following format:
       # <https://api.github.com/user/repos?per_page=100&page=2>; rel="last",
       # <https://api.github.com/user/repos?per_page=100&page=2>; rel="next"

--- a/lib/github/api.rb
+++ b/lib/github/api.rb
@@ -10,14 +10,49 @@ require 'config_path'
 
 module Github
   class Api
-    LEGACY_HOST_FILE = '~/.github-repos/host'.freeze
-    DEFAULT_HOST = 'https://api.github.com'.freeze
-    HOST_FILE_NAME = 'host'.freeze
+    LEGACY_HOST_FILE = '~/.github-repos/host'
+    DEFAULT_HOST = 'https://api.github.com'
+    HOST_FILE_NAME = 'host'
+    CACHE_FILE_NAME = 'cache'
 
-    def search_repos(query)
+    # 100 is maximum items per page
+    LIST_USER_REPOS_PATH = '/user/repos?per_page=100'
+
+    def search_all_repos(query)
       path = "/search/repositories?q=#{escape(query)}"
 
-      get(path)[:items]
+      repos = get(path)[:body][:items]
+      Github::RepoFormatter.new(repos).to_formatted_hash
+    end
+
+    def search_repos(query)
+      query_downcase = query.downcase
+
+      repos = cached_repos
+      repos = reset_cache if repos.empty?
+
+      repos_filtered = repos.filter do |i|
+        title_downcase = i[:title].downcase
+        title_downcase.include?(query_downcase)
+      end
+
+      repos_filtered
+    end
+
+    def reset_cache
+      next_page = 1
+      repos = []
+
+      until next_page.nil?
+        response = get(LIST_USER_REPOS_PATH + "&page=#{next_page}")
+        repos.push(*response[:body])
+        next_page = response[:next_page]
+      end
+
+      repos_formatted = Github::RepoFormatter.new(repos).to_formatted_hash
+
+      save_repos_to_disk(repos_formatted)
+      repos_formatted
     end
 
     class << self
@@ -43,11 +78,6 @@ module Github
 
     def get(path)
       req = Net::HTTP::Get.new(path)
-      res = process_request(req)
-      res.body
-    end
-
-    def process_request(req)
       uri = URI("#{host}#{req.path}")
 
       authorize(req)
@@ -56,8 +86,11 @@ module Github
         yield(http) if block_given?
         http.request(req)
       end
-      res.body = parse_body(res.body)
-      res
+
+      {
+        body: parse_body(res.body),
+        next_page: get_next_page(res[:link])
+      }
     end
 
     def auth
@@ -76,6 +109,30 @@ module Github
       return body if body.nil? || body.empty?
 
       JSON.parse(body, symbolize_names: true)
+    end
+
+    def get_next_page(header)
+      # GitHub pagination returns a "Link" header in the following format:
+      # <https://api.github.com/user/repos?per_page=100&page=2>; rel="last",
+      # <https://api.github.com/user/repos?per_page=100&page=2>; rel="next"
+      # We are currently interested only in the "next" link.
+
+      # Proceed with part in the < > only if "next" word is in the string
+      # In lt/gt "brackets", match digit after "page" query string, ensuring
+      # it's not a "per_page" parameter by asking for [&?] to precede "page".
+      regex = /<.+[&?]page=(\d+).*>.+next/
+      header.split(',').map { |i| i[regex, 1] }.find(&:itself)
+    end
+
+    def save_repos_to_disk(repos)
+      cache = LocalStorage.new(ConfigPath.new(CACHE_FILE_NAME).get)
+      cache.put(repos.to_json)
+    end
+
+    def cached_repos
+      cache_path = ConfigPath.new(CACHE_FILE_NAME).get
+      cache_string = LocalStorage.new(cache_path).get
+      cache_string.nil? ? [] : JSON.parse(cache_string, symbolize_names: true)
     end
   end
 end

--- a/lib/github/repo_formatter.rb
+++ b/lib/github/repo_formatter.rb
@@ -8,12 +8,10 @@ module Github
       @repos = repos
     end
 
-    def to_json(*_args)
-      items = @repos.map do |repo|
+    def to_formatted_hash
+      @repos.map do |repo|
         format_repo(repo)
       end
-
-      JSON.generate(items: items)
     end
 
     private


### PR DESCRIPTION
Hi @edgarjs!

First of all, thank you for creating that workflow!

Just as @jescalan at #15 I found that being able to only query all repositories is very limiting. In fact, 99% of the time when I need to open a repository quickly though Alfred - it's one of the repositories I'm contributing to.

I've implemented my version of the caching functionality which you can take a look at in this PR.

I haven't code in Ruby for a few years now, so, excuse me and point to the imperfections.

Changes:
- `search` command is now only searching through the user's repositories, not involving repositories from `/search/repositories?q=`.
- `search-all` command now does what `search` used to do.
- Added `reset-cache` command, which will re-download user repositories to the disk. Alternatively, the cache will be downloaded in case if it does not exist.
- Changed semantics of `Github::RepoFormatter`. It used to output alfred-ready final JSON (with `items:` as a top-level key). Now it just transforms raw github repositories to the alfred-friendly item format. I found this reasonable since all the final formatting for alfred (wrapping items to the JSON with `items:` key) happens in the `bin/github-repos`, so why should we hide this step for search commands.

Notes and possible improvements:
- Currently, we're saving repositories to the cache and operating on them in alfred-friendly format (i.e. the output of RepoFormatter), which is not efficient by any means. In fact, we only need a repository full name and GitHub host. It would be nice if we add another abstraction around that and generate alfred items right before we send them, which should drastically increase speed we search through a cache and reduce cache size itself.
- A cache is not automatically updated now. It only downloaded if not exists or if `reset-cache` is called. We probably should add an automatic update if it's older than X. What do you think?
- It would be nice to make the fuzzy search a little more sophisticated. Now I'm just checking if a query is a substring of some repository name.
- I'm not sure what is the right way of generating new `info.plist`. I just imported it to the alfred, made changes and took this file from the "export" archive. I hope it's fine 🤔 
- I had thoughts about merging search-all and cached user repositories, but the problem is that we can't show cached results fast and then update output with additional items returned from the search request. I believe it's a limitation of alfred itself that we only can return one `{ "items": ... }` per script.

Thank you.