### PR TITLE
Rework of caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can also check the [releases history](https://github.com/edgarjs/alfred-gith
 
 1. Search your repositories by calling the `gh <term>` action.
 2. Search all repositories by calling the `gha <term>` action.
-3. Your repositories are cached and updated every 24 hours. To force re-download cache use `gh-reset-cache` action.
+3. Your repositories are cached. To force re-download cache use `gh-reset-cache` action or choose corresponding item in the `gh <term>` action.
 
 ### Other Actions
 

--- a/info.plist
+++ b/info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>bundleid</key>
 	<string>edgarjs.github-repos.workflow</string>
-	<key>category</key>
-	<string>Internet</string>
 	<key>connections</key>
 	<dict>
 		<key>2BD5A2D8-1263-445C-818F-1149B117043F</key>
@@ -36,6 +34,19 @@
 		</array>
 		<key>4EADFDC9-FA77-4A5E-AC45-FFCF4560CD23</key>
 		<array/>
+		<key>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>AC7DFF5B-3DC4-4F5D-AEE2-CCF983480200</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>5A5FFC2F-634C-4DD4-A895-CB0E3C61BDD8</key>
 		<array>
 			<dict>
@@ -53,7 +64,7 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</string>
+				<string>E3EA59F0-DC3B-4D6B-B86E-8226B334CB78</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -79,6 +90,31 @@
 		</array>
 		<key>B95D5B79-1099-4505-8C73-B9432D0FEF27</key>
 		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>E3EA59F0-DC3B-4D6B-B86E-8226B334CB78</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>1085964B-9CDA-4CFF-BC0A-FFE1DA4E66BF</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
 			<dict>
 				<key>destinationuid</key>
 				<string>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</string>
@@ -201,134 +237,6 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
-				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>https://github.com/settings/tokens/new?description=Github%20Repos&amp;scopes=repo</string>
-				<key>utf8</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
-			<key>uid</key>
-			<string>74368575-DA05-42F3-A54D-63168FF72AC8</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argumenttype</key>
-				<integer>2</integer>
-				<key>keyword</key>
-				<string>gh-token</string>
-				<key>subtext</key>
-				<string>Use this token in the gh-login call</string>
-				<key>text</key>
-				<string>Generate personal access token</string>
-				<key>withspace</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
-			<key>uid</key>
-			<string>F2578320-696B-4844-AE63-6A9B88C77B26</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argumenttype</key>
-				<integer>2</integer>
-				<key>keyword</key>
-				<string>gh-reset-cache</string>
-				<key>subtext</key>
-				<string>gh-reset-cache</string>
-				<key>text</key>
-				<string>Update github cache</string>
-				<key>withspace</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
-			<key>uid</key>
-			<string>B95D5B79-1099-4505-8C73-B9432D0FEF27</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>concurrently</key>
-				<false/>
-				<key>escaping</key>
-				<integer>102</integer>
-				<key>script</key>
-				<string>./bin/github-repos reset-cache</string>
-				<key>scriptargtype</key>
-				<integer>1</integer>
-				<key>scriptfile</key>
-				<string></string>
-				<key>type</key>
-				<integer>0</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>concurrently</key>
-				<false/>
-				<key>escaping</key>
-				<integer>102</integer>
-				<key>script</key>
-				<string>bin/github-repos authenticate $1 $2</string>
-				<key>scriptargtype</key>
-				<integer>1</integer>
-				<key>scriptfile</key>
-				<string></string>
-				<key>type</key>
-				<integer>0</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>4EADFDC9-FA77-4A5E-AC45-FFCF4560CD23</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argumenttype</key>
-				<integer>1</integer>
-				<key>keyword</key>
-				<string>gh-login</string>
-				<key>subtext</key>
-				<string>gh-login &lt;email&gt; &lt;token&gt;</string>
-				<key>text</key>
-				<string>Store github credentials</string>
-				<key>withspace</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
-			<key>uid</key>
-			<string>5A5FFC2F-634C-4DD4-A895-CB0E3C61BDD8</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>alfredfiltersresults</key>
 				<false/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -374,6 +282,109 @@
 			<string>B6461D97-4545-4CC6-8441-EBB26BB5E8E3</string>
 			<key>version</key>
 			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{query}</string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>CE432EBB-9EC4-4951-BD09-36414AF0AD62</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>https://github.com/settings/tokens/new?description=Github%20Repos&amp;scopes=repo</string>
+				<key>utf8</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>74368575-DA05-42F3-A54D-63168FF72AC8</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>2</integer>
+				<key>keyword</key>
+				<string>gh-token</string>
+				<key>subtext</key>
+				<string>Use this token in the gh-login call</string>
+				<key>text</key>
+				<string>Generate personal access token</string>
+				<key>withspace</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>F2578320-696B-4844-AE63-6A9B88C77B26</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>bin/github-repos authenticate $1 $2</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>4EADFDC9-FA77-4A5E-AC45-FFCF4560CD23</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>keyword</key>
+				<string>gh-login</string>
+				<key>subtext</key>
+				<string>gh-login &lt;email&gt; &lt;token&gt;</string>
+				<key>text</key>
+				<string>Store github credentials</string>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>5A5FFC2F-634C-4DD4-A895-CB0E3C61BDD8</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -439,26 +450,102 @@
 			<key>type</key>
 			<string>alfred.workflow.action.openurl</string>
 			<key>uid</key>
-			<string>CE432EBB-9EC4-4951-BD09-36414AF0AD62</string>
+			<string>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>browser</key>
-				<string></string>
-				<key>spaces</key>
-				<string></string>
-				<key>url</key>
-				<string>{query}</string>
-				<key>utf8</key>
-				<true/>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>1</integer>
+						<key>matchstring</key>
+						<string>reset_cache</string>
+						<key>outputlabel</key>
+						<string>Record is in cache</string>
+						<key>uid</key>
+						<string>1085964B-9CDA-4CFF-BC0A-FFE1DA4E66BF</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>else</string>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.action.openurl</string>
+			<string>alfred.workflow.utility.conditional</string>
 			<key>uid</key>
-			<string>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</string>
+			<string>E3EA59F0-DC3B-4D6B-B86E-8226B334CB78</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>2</integer>
+				<key>keyword</key>
+				<string>gh-reset-cache</string>
+				<key>subtext</key>
+				<string>gh-reset-cache</string>
+				<key>text</key>
+				<string>Update github cache</string>
+				<key>withspace</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>B95D5B79-1099-4505-8C73-B9432D0FEF27</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>./bin/github-repos reset-cache</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>lastpathcomponent</key>
+				<false/>
+				<key>onlyshowifquerypopulated</key>
+				<false/>
+				<key>removeextension</key>
+				<false/>
+				<key>text</key>
+				<string>Successfully refreshed cached repositories</string>
+				<key>title</key>
+				<string>Alfred Github Workflow</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.notification</string>
+			<key>uid</key>
+			<string>AC7DFF5B-3DC4-4F5D-AEE2-CCF983480200</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -486,106 +573,120 @@ NOTE: This is an experimental feature that may not work as expected, if you find
 		<key>2BD5A2D8-1263-445C-818F-1149B117043F</key>
 		<dict>
 			<key>xpos</key>
-			<integer>50</integer>
-			<key>ypos</key>
 			<integer>20</integer>
+			<key>ypos</key>
+			<integer>50</integer>
 		</dict>
 		<key>381B37AB-78A2-43C6-9D32-878D4A81B5B5</key>
 		<dict>
 			<key>xpos</key>
-			<integer>450</integer>
+			<integer>520</integer>
 			<key>ypos</key>
-			<integer>15</integer>
+			<integer>50</integer>
 		</dict>
 		<key>4EADFDC9-FA77-4A5E-AC45-FFCF4560CD23</key>
 		<dict>
 			<key>xpos</key>
-			<integer>280</integer>
+			<integer>360</integer>
 			<key>ypos</key>
-			<integer>290</integer>
+			<integer>320</integer>
 		</dict>
 		<key>546DCD00-51F9-4C9D-BEE4-E60AD25CB3BC</key>
 		<dict>
 			<key>xpos</key>
-			<integer>640</integer>
+			<integer>360</integer>
 			<key>ypos</key>
-			<integer>165</integer>
+			<integer>650</integer>
 		</dict>
 		<key>5A5FFC2F-634C-4DD4-A895-CB0E3C61BDD8</key>
 		<dict>
 			<key>xpos</key>
-			<integer>50</integer>
+			<integer>20</integer>
 			<key>ypos</key>
-			<integer>290</integer>
+			<integer>320</integer>
 		</dict>
 		<key>72D9F53C-2F43-447A-8012-CA07801C1407</key>
 		<dict>
 			<key>xpos</key>
-			<integer>50</integer>
+			<integer>20</integer>
 			<key>ypos</key>
-			<integer>440</integer>
+			<integer>460</integer>
 		</dict>
 		<key>74368575-DA05-42F3-A54D-63168FF72AC8</key>
 		<dict>
 			<key>xpos</key>
-			<integer>280</integer>
+			<integer>360</integer>
 			<key>ypos</key>
-			<integer>150</integer>
+			<integer>180</integer>
 		</dict>
 		<key>7B59839B-A868-4F5C-8A93-5AFD865D55AE</key>
 		<dict>
 			<key>xpos</key>
-			<integer>640</integer>
+			<integer>710</integer>
 			<key>ypos</key>
-			<integer>15</integer>
+			<integer>50</integer>
 		</dict>
 		<key>7FD2F7D8-60D9-49F4-BA70-C256B0426A38</key>
 		<dict>
 			<key>xpos</key>
-			<integer>280</integer>
+			<integer>360</integer>
 			<key>ypos</key>
-			<integer>20</integer>
+			<integer>50</integer>
+		</dict>
+		<key>AC7DFF5B-3DC4-4F5D-AEE2-CCF983480200</key>
+		<dict>
+			<key>xpos</key>
+			<integer>520</integer>
+			<key>ypos</key>
+			<integer>650</integer>
 		</dict>
 		<key>B6461D97-4545-4CC6-8441-EBB26BB5E8E3</key>
 		<dict>
 			<key>xpos</key>
-			<integer>465</integer>
+			<integer>520</integer>
 			<key>ypos</key>
-			<integer>440</integer>
+			<integer>180</integer>
 		</dict>
 		<key>B95D5B79-1099-4505-8C73-B9432D0FEF27</key>
 		<dict>
 			<key>xpos</key>
-			<integer>450</integer>
+			<integer>20</integer>
 			<key>ypos</key>
-			<integer>165</integer>
+			<integer>650</integer>
 		</dict>
 		<key>BBD79FE5-D671-40AB-A1EE-AEBE941E2FCB</key>
 		<dict>
 			<key>xpos</key>
-			<integer>280</integer>
+			<integer>360</integer>
 			<key>ypos</key>
-			<integer>440</integer>
+			<integer>460</integer>
 		</dict>
 		<key>CE432EBB-9EC4-4951-BD09-36414AF0AD62</key>
 		<dict>
 			<key>xpos</key>
-			<integer>695</integer>
+			<integer>710</integer>
 			<key>ypos</key>
-			<integer>440</integer>
+			<integer>180</integer>
+		</dict>
+		<key>E3EA59F0-DC3B-4D6B-B86E-8226B334CB78</key>
+		<dict>
+			<key>xpos</key>
+			<integer>175</integer>
+			<key>ypos</key>
+			<integer>580</integer>
 		</dict>
 		<key>F2578320-696B-4844-AE63-6A9B88C77B26</key>
 		<dict>
 			<key>xpos</key>
-			<integer>50</integer>
+			<integer>20</integer>
 			<key>ypos</key>
-			<integer>150</integer>
+			<integer>180</integer>
 		</dict>
 	</dict>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>webaddress</key>
 	<string>https://github.com/edgarjs/alfred-github-repos</string>
 </dict>

--- a/lib/github/api.rb
+++ b/lib/github/api.rb
@@ -145,6 +145,8 @@ module Github
       cache_storage.put(content)
     end
 
+    # If you're looking for a way to check how old cache is -
+    # look at code prior to commit 28e5ddd034552ec2b2df68ad5657adcdc093418e
     def read_cached_repos
       cache_string = cache_storage.get
       return [] if cache_string.nil?


### PR DESCRIPTION
Waiting for cache to re-download once a day is indeed pain.
I will not get into details why one or another solution of somewhat silently reloading cache wouldn't work, instead feel free to propose different options if you think they'll work better!
For now what I did is completely disabled automatic refresh, instead you can choose “reset cache” option if your search has no results in cache.

Had to update workflow graph itself which looks like that now:
![image](https://user-images.githubusercontent.com/10668780/88713146-1f705880-d11b-11ea-92ef-8094ef141335.png)

What you see when your repository not found:
![image](https://user-images.githubusercontent.com/10668780/88713185-3151fb80-d11b-11ea-935b-fdbb8e0fed20.png)

I have bumped the version number as well, though probably should've leave it to you.

Thank you.