### PR TITLE
Fix path for Github Enterprise Edition by prefixing `HTTP::Get` paths with `/api/v3`

### DIFF
--- a/lib/github/api.rb
+++ b/lib/github/api.rb
@@ -86,8 +86,8 @@ module Github
     end
 
     def get(path)
-      req = Net::HTTP::Get.new(path)
-      uri = URI("#{host}#{req.path}")
+      uri = URI("#{host}#{path}")
+      req = Net::HTTP::Get.new(uri.path)
 
       authorize(req)
 


### PR DESCRIPTION
With v2.1.4 installed on my Alfred 4, I tried to connect to a Github EE host, the `gh-host` and `gh-login` work as expected, but `gh my-search-keyword` fails with an `Invalid Response` prompt.

When printing out the error message at https://github.com/edgarjs/alfred-github-repos/blob/2.1.4/bin/github-repos#L79-L80, the response body is a HTML containing the link to Github EE's login page.

The root cause is the request path:
* Expected Get URL: `https://my-github-ee.example.com/api/v3/search/repositories`
* Actual Get URL: `https://my-github-ee.example.com/search/repositories`
The target Github EE instance only treat `/api/v3/*` as REST API calls.

So the fix is to make sure the `path` of Get request is prefixed with `/api/v3`.

Please note that this fix is only against the `2.1.4` tag. I haven't found any counterparts in `master` branch yet.